### PR TITLE
Add bioconda badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # EMU
+
 [![](https://anaconda.org/bioconda/emu-pca/badges/downloads.svg)](https://anaconda.org/bioconda/emu-pca)
 
 EMU is a software for performing principal component analysis (PCA) in the presence of missingness for genetic datasets. EMU can handle both random and non-random missingness by modelling it directly through a truncated SVD approach. EMU uses binary PLINK files as input.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # EMU
+
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?colorB=58bd9f&style=popout)](http://bioconda.github.io/recipes/emu-pca/README.html)
+
 EMU is a software for performing principal component analysis (PCA) in the presence of missingness for genetic datasets. EMU can handle both random and non-random missingness by modelling it directly through a truncated SVD approach. EMU uses binary PLINK files as input.
 
 ### Citation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # EMU
-
-[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?colorB=58bd9f&style=popout)](http://bioconda.github.io/recipes/emu-pca/README.html)
+[![](https://anaconda.org/bioconda/emu-pca/badges/downloads.svg)](https://anaconda.org/bioconda/emu-pca)
 
 EMU is a software for performing principal component analysis (PCA) in the presence of missingness for genetic datasets. EMU can handle both random and non-random missingness by modelling it directly through a truncated SVD approach. EMU uses binary PLINK files as input.
 


### PR DESCRIPTION
EMU is now available on bioconda under `emu-pca` (`emu` was already taken).

I added a badge to the readme to denote that. 

There are various other badges you can substitute for this one if you prefer: https://anaconda.org/bioconda/emu-pca/badges

